### PR TITLE
Feat (*) - add the optional parameter private_key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,10 @@ doc/_build
 doc/gitlab_backup.1
 
 README
+
+# RSA
 id_rsa
 id_rsa.pub
+
+# Virtual env
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ doc/_build
 doc/gitlab_backup.1
 
 README
+id_rsa
+id_rsa.pub

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ CLI Usage is as follows::
                          [--namespace NAMESPACE]
                          [--output-directory OUTPUT_DIRECTORY] [--prefer-ssh]
                          [--skip-existing]
+                         [--private_key]
 
     Backup a gitlab account
 
@@ -59,6 +60,7 @@ CLI Usage is as follows::
       --prefer-ssh          Clone repositories using SSH instead of HTTPS
       --skip-existing       skip project if a backup directory exists
       --with-membership     Backup projects provided user or key is member of
+      --private_key         To specify a private key
 
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/gitlab-backup.svg

--- a/bin/gitlab-backup
+++ b/bin/gitlab-backup
@@ -333,11 +333,21 @@ def parse_args():
                         action='store_true',
                         dest='with_membership',
                         help='Backup projects provided user or key is member of')
+    parser.add_argument('--private_key',
+                        default='',
+                        dest='private_key',
+                        help='Path to the private key')
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
+
+    if args.private_key != '':
+        log_info('Use the private key: {0}'.format(args.private_key))
+        os.environ["GIT_SSH_COMMAND"] = 'ssh -i "{0}" -o IdentitiesOnly=yes'.format(args.private_key)
+        print(os.environ["GIT_SSH_COMMAND"])
+
     client = get_client(args)
     if not client:
         log_fail('Unable to create gitlab client')


### PR DESCRIPTION
Hi, 

to let the possibility to use a specific private key, i add the optional parameter --private_key

example of use:
`python bin/gitlab-backup --host https://XXX.com --private-token XXXX --private_key \_keys\id_rsa`

feel free to tell me for any comment 

;)

