### PR TITLE
fix(gitlab): set get_all=True on projects list

### DIFF
--- a/bin/gitlab-backup
+++ b/bin/gitlab-backup
@@ -397,7 +397,7 @@ def main():
         mkdir_p(output_directory)
 
     items = client.projects.list(
-        as_list=False, owned=args.owned_only, membership=args.with_membership
+        get_all=True, owned=args.owned_only, membership=args.with_membership
     )
     repositories = {}
     for item in items:


### PR DESCRIPTION
Replace deprecated as_list=False parameter with get_all=True in client.projects.list to prevent UserWarning and ensure all repositories are fetched.

```
UserWarning: Calling a `list()` method without specifying `get_all=True` or `iterator=True` will return a maximum of 20 items. Your query returned 20 of XXX items. See https://python-gitlab.readthedocs.io/en/v8.5.0/api-usage.html#pagination for more details. If this was done intentionally, then this warning can be supressed by adding the argument `get_all=False` to the `list()` call.
```