### PR TITLE
fix(lfs): remove unsupported --force and --tags flags from git lfs fetch

### DIFF
--- a/bin/gitlab-backup
+++ b/bin/gitlab-backup
@@ -196,8 +196,6 @@ def fetch_repository(
                 "lfs",
                 "fetch",
                 "--all",
-                "--force",
-                "--tags",
                 "--prune",
             ]
         else:


### PR DESCRIPTION
git lfs fetch does not accept --force or --tags flags. Passing them causes git-lfs to fail with exit code 127.